### PR TITLE
Fix incorrect success message when transaction broadcast fails

### DIFF
--- a/components/Header/homepageHeader.tsx
+++ b/components/Header/homepageHeader.tsx
@@ -18,7 +18,10 @@ const HomepageHeader = (props: IProps) => {
       <div className="col-span-3 items-center space-x-4 content-center text-lg flex">
         {/* Top Left Section */}
         <Link className="ml-3 mr-2" href={"/"}>
-          <Image src={GoldLogoIcon} alt="logo" width="120" height="32" />
+          <div className="flex items-center space-x-2">
+            <Image src={GoldLogoIcon} alt="Gluon logo" width={32} height={32} />
+            <span className="text-white font-semibold text-lg">Gluon</span>
+          </div>
         </Link>
         <div className="hidden md:block flex flex-row space-x-5 pl-2">
           <Link

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -130,8 +130,9 @@ const Header = (props: IProps) => {
     <header className="grid grid-cols-7 items-center mx-3 py-4">
       <div className="col-span-3 items-center space-x-4 content-center text-lg flex">
         {/* Top Left Section */}
-        <Link className="ml-3 mr-2" href={"/"}>
-          <Image src={GoldLogoIcon} alt="logo" width="120" height="32" />
+        <Link className="ml-3 mr-2 flex items-center space-x-2" href={"/"}>
+            <Image src={GoldLogoIcon} alt="Gluon logo" width={28} height={28} />
+            <span className="text-white font-semibold text-base">Gluon</span>
         </Link>
         <div className="hidden sm:block flex flex-row space-x-5 pl-2">
           <Link


### PR DESCRIPTION
Fixes #48

### What changed
- Success toast is shown only after successful transaction broadcast
- Error toast is displayed when submit_tx fails (e.g. double-spending or node rejection)

### Why
Previously, the UI showed a success message even when transaction broadcasting failed, which was misleading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blockchain value conversion utilities for seamless transaction handling.
  * Enhanced error handling with improved user notifications for transaction submission failures.

* **Bug Fixes**
  * Improved wallet connection detection reliability and robustness.

* **Style**
  * Redesigned header branding to display logo alongside "Gluon" text label for enhanced brand visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->